### PR TITLE
Add LLVM/Clang packages for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y clang llvm-dev libclang-dev
       - name: Install maturin
         run: pip install maturin
       - name: Build wheels


### PR DESCRIPTION
## Summary
- install llvm and clang in CI so clang-sys can build

## Testing
- `cargo test --workspace` *(fails: missing method `reshape` for struct `Mat`)*

------
https://chatgpt.com/codex/tasks/task_e_68882a4cece48321a875d1b69b8fba30