### PR TITLE
Fix OpenCV detection in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,13 @@ jobs:
         arch: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Install Python
@@ -16,7 +23,11 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang-14 llvm-14-dev libclang-14-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang-14 llvm-14-dev libclang-14-dev \
+            libopencv-dev pkg-config
       - name: Install maturin
         run: pip install maturin
       - name: Build wheels

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ control board or custom driver board, in a custom designed case so you can attac
 device for low-cost, simple and open-source site-specific weed control. Projects to date have seen OWL mounted on robots,
 vehicles and bicycles for spot spraying. For the latest ideas and news, check out the [Discussion](https://github.com/geezacoleman/OpenWeedLocator/discussions) tab.
 
-> **Note**: This fork integrates experimental Rust components for improved performance. It is under active development and APIs may change.
+> **Note**: This fork integrates experimental Rust components for improved performance. It is under active development and APIs may change. See [docs/opencv_build.md](docs/opencv_build.md) for details on setting up the OpenCV dependencies required for building the Rust code.
 
 ### News
 **14-02-2025** - Complete OWL software installation guide now on YouTube

--- a/docs/opencv_build.md
+++ b/docs/opencv_build.md
@@ -1,0 +1,18 @@
+# Building OpenCV and Rust bindings
+
+This project uses the Rust `opencv` crate for performance sensitive code. The crate expects OpenCV development headers to be available. In CI we install the `libopencv-dev` package so the build script can detect OpenCV via `pkg-config`.
+
+For local development on Ubuntu run:
+
+```bash
+sudo apt-get update
+sudo apt-get install libopencv-dev clang llvm-dev libclang-dev pkg-config
+```
+
+When OpenCV is not available system-wide you can fall back to a vendored build by setting:
+
+```bash
+export OPENCV_VENDORED=1
+```
+
+which compiles OpenCV from source, but increases build time significantly.


### PR DESCRIPTION
## Summary
- install OpenCV development packages in CI
- cache cargo registry to speed up workflow
- document OpenCV setup steps
- reference new docs from README

## Testing
- `cargo test --workspace` *(fails: could not compile `owl-vision`)*
- `pip install dist/*.whl` *(fails: wheel file not found)*

------
https://chatgpt.com/codex/tasks/task_e_688831a5d2f48321832449f8f80d8004