### PR TITLE
Add configurable log level

### DIFF
--- a/src/bin/openweedlocator/main.rs
+++ b/src/bin/openweedlocator/main.rs
@@ -1,0 +1,18 @@
+use std::env;
+use log::LevelFilter;
+
+fn init_logging() {
+    let level = env::var("LOG_LEVEL")
+        .ok()
+        .and_then(|lvl| lvl.parse::<LevelFilter>().ok())
+        .unwrap_or(LevelFilter::Debug);
+    env_logger::Builder::new()
+        .filter_level(level)
+        .format_timestamp(None)
+        .init();
+}
+
+fn main() {
+    init_logging();
+    println!("OpenWeedLocator starting with log level: {:?}", log::max_level());
+}


### PR DESCRIPTION
## Summary
- make log level configurable via `LOG_LEVEL` env var

## Testing
- `cargo check --workspace` *(fails: couldn't find any valid libclang)*

------
https://chatgpt.com/codex/tasks/task_e_688bdc05399883219b1e3dc3818a1243