### PR TITLE
Improve build dependency docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ control board or custom driver board, in a custom designed case so you can attac
 device for low-cost, simple and open-source site-specific weed control. Projects to date have seen OWL mounted on robots,
 vehicles and bicycles for spot spraying. For the latest ideas and news, check out the [Discussion](https://github.com/geezacoleman/OpenWeedLocator/discussions) tab.
 
-> **Note**: This fork integrates experimental Rust components for improved performance. It is under active development and APIs may change. See [docs/opencv_build.md](docs/opencv_build.md) for details on setting up the OpenCV dependencies required for building the Rust code.
+> **Note**: This fork integrates experimental Rust components for improved performance. It is under active development and APIs may change. See [docs/opencv_build.md](docs/opencv_build.md) for details on setting up the OpenCV dependencies required for building the Rust code. The build will exit early with a helpful message if these dependencies are missing.
 
 ### News
 **14-02-2025** - Complete OWL software installation guide now on YouTube

--- a/docs/opencv_build.md
+++ b/docs/opencv_build.md
@@ -16,3 +16,23 @@ export OPENCV_VENDORED=1
 ```
 
 which compiles OpenCV from source, but increases build time significantly.
+
+If these packages are missing the Rust build will exit with an error similar to:
+
+```
+error: OpenCV development libraries not found. Install 'libopencv-dev' or set OPENCV_VENDORED=1 to build from source.
+```
+
+This helps diagnose missing dependencies before a lengthy compile starts.
+
+To use the latest clang toolchain on CI or GitHub Actions you can run:
+```
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh 18
+sudo apt-get install -y clang-18 libclang-18-dev
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
+export LIBCLANG_PATH=/usr/lib/llvm-18/lib
+```
+This ensures the OpenCV bindings are compiled against a recent Clang and libclang.

--- a/rust-core/python-bindings/build.rs
+++ b/rust-core/python-bindings/build.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+
+fn main() {
+    if Command::new("pkg-config").arg("--libs").arg("opencv4").output().is_err() {
+        eprintln!("error: OpenCV development libraries not found. Install 'libopencv-dev' or set OPENCV_VENDORED=1 to build from source.");
+        std::process::exit(1);
+    }
+    if Command::new("clang").arg("--version").output().is_err() {
+        eprintln!("error: clang is required to build the Rust OpenCV bindings. Please install clang and libclang-dev.");
+        std::process::exit(1);
+    }
+
+    // ensure libclang is discoverable
+    if std::env::var("LIBCLANG_PATH").is_err() {
+        if !std::path::Path::new("/usr/lib/llvm-18/lib").exists() {
+            eprintln!("error: libclang not found. Set LIBCLANG_PATH to the directory containing libclang.so");
+            std::process::exit(1);
+        }
+    }
+}

--- a/rust-core/python-bindings/build.rs
+++ b/rust-core/python-bindings/build.rs
@@ -12,7 +12,16 @@ fn main() {
 
     // ensure libclang is discoverable
     if std::env::var("LIBCLANG_PATH").is_err() {
-        if !std::path::Path::new("/usr/lib/llvm-18/lib").exists() {
+        let common_paths = vec![
+            "/usr/lib/llvm-18/lib",
+            "/usr/lib/llvm-17/lib",
+            "/usr/lib/llvm-16/lib",
+            "/usr/local/lib",
+            "/opt/homebrew/opt/llvm/lib", // Common on macOS with Homebrew
+        ];
+        let libclang_path = common_paths.iter()
+            .find(|path| std::path::Path::new(path).exists());
+        if libclang_path.is_none() {
             eprintln!("error: libclang not found. Set LIBCLANG_PATH to the directory containing libclang.so");
             std::process::exit(1);
         }


### PR DESCRIPTION
## Summary
- add clang setup instructions
- ensure build script checks LIBCLANG_PATH

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_688bdee0b1e4832188bd4b427211948e