### PR TITLE
Add Rust-Spray detector backend as opt-in inner loop

### DIFF
--- a/config/GENERAL_CONFIG.ini
+++ b/config/GENERAL_CONFIG.ini
@@ -57,6 +57,18 @@ brightness_max = 190
 min_detection_area = 10
 invert_hue = False
 
+[RustSpray]
+# Optional high-performance inner loop (set System.algorithm = rustspray).
+# Requires the Rust-Spray binary: github.com/cropcrusaders/Rust-Spray
+# Colour thresholds and GPIO pins are read from Rust-Spray's own TOML config
+# and must match the [Relays] wiring above. If the subprocess crashes or
+# times out more than max_restarts times, OWL falls back to the exg detector.
+binary = /usr/local/bin/rustspray
+config = /etc/rustspray/config.toml
+mock_gpio = False
+frame_timeout_ms = 100
+max_restarts = 3
+
 [DataCollection]
 image_sample_enable = False
 detection_enable = True

--- a/config/README.md
+++ b/config/README.md
@@ -38,6 +38,7 @@ You can create custom presets by saving from the dashboard. Custom presets are s
 | `[DataCollection]` | Image sampling settings, save directory, logging |
 | `[Relays]` | Maps relay IDs to GPIO pin numbers |
 | `[Tracking]` | ByteTrack weed tracking settings |
+| `[RustSpray]` | Optional Rust-Spray high-performance detection backend |
 | `[Visualisation]` | Display settings when running with `--show-display` |
 | `[Sensitivity]` | Active sensitivity preset |
 | `[Sensitivity_Low/Medium/High]` | Built-in sensitivity preset thresholds |
@@ -52,7 +53,7 @@ Defaults shown are from `GENERAL_CONFIG.ini`.
 
 | Key | Default | Range / Valid values | Description |
 |-----|---------|---------------------|-------------|
-| `algorithm` | `exhsv` | `exg`, `exgr`, `maxg`, `nexg`, `exhsv`, `hsv`, `gndvi`, `gog`, `gog-hybrid` | Detection algorithm (see table below) |
+| `algorithm` | `exhsv` | `exg`, `exgr`, `maxg`, `nexg`, `exhsv`, `hsv`, `gndvi`, `gog`, `gog-hybrid`, `rustspray` | Detection algorithm (see table below) |
 | `input_file_or_directory` | *(empty)* | File or directory path | Path to video, image, or directory for offline processing. Leave empty for live camera |
 | `relay_num` | `4` | 0+ (integer) | Number of relays connected to the OWL. Must match entries in `[Relays]` |
 | `actuation_duration` | `0.15` | Seconds (float) | How long each relay stays on when a weed is detected |
@@ -72,6 +73,7 @@ Defaults shown are from `GENERAL_CONFIG.ini`.
 | `gndvi` | Green NDVI | (NIR - green) / (NIR + green) | **Requires NIR camera.** Not for standard setups |
 | `gog` | Green-on-Green | Ultralytics YOLO object detection | For in-crop weed detection. Requires a trained model (see `[GreenOnGreen]`) |
 | `gog-hybrid` | AI + Colour | YOLO crop mask + ExHSV colour detection | Uses YOLO to identify crop regions, then runs ExHSV on non-crop areas. Best of both worlds for in-crop scenarios |
+| `rustspray` | Rust-Spray backend | SIMD ExG / green-ratio / chroma in a Rust subprocess | Requires the [Rust-Spray](https://github.com/cropcrusaders/Rust-Spray) binary (see `[RustSpray]`). Falls back to `exg` automatically on failure |
 
 All algorithms except `gog`, `gog-hybrid`, and `hsv` use the `[GreenOnBrown]` thresholds. The `hsv` algorithm uses only the HSV thresholds (hue, saturation, brightness). The `gog` algorithm ignores `[GreenOnBrown]` entirely and uses `[GreenOnGreen]` settings instead. The `gog-hybrid` algorithm uses both `[GreenOnGreen]` (for YOLO crop detection) and `[GreenOnBrown]` (for ExHSV weed detection in non-crop areas).
 
@@ -139,6 +141,22 @@ Optional weed tracking using ByteTrack. When enabled, YOLO runs in tracking mode
 | `tracking_enabled` | `False` | `True` / `False` | Enable ByteTrack weed tracking |
 | `track_class_window` | `5` | 1+ (integer) | Number of recent frames to use for majority-vote class smoothing |
 | `track_crop_persist` | `3` | 0+ (integer) | Number of frames to persist a crop mask after the crop is no longer detected. Only used in `gog-hybrid` mode |
+
+### `[RustSpray]`
+
+Used when `algorithm = rustspray`. Runs the [Rust-Spray](https://github.com/cropcrusaders/Rust-Spray) binary as a high-performance detection inner loop: OWL keeps capturing frames with picamera2 and streams them to the subprocess as raw RGB24 over stdin; Rust-Spray returns per-lane spray decisions as newline-delimited JSON (IPC protocol v1, documented in Rust-Spray's `INTEGRATION.md`).
+
+Colour thresholds and solenoid GPIO pins are configured in Rust-Spray's own TOML file, **not** in `[GreenOnBrown]` or `[Relays]`. If Rust-Spray drives the GPIO pins directly, its TOML pin assignments must match the `[Relays]` wiring — alternatively set `mock_gpio = True` and let OWL's relay controller keep driving the pins from the lane states.
+
+At startup OWL verifies the binary's IPC protocol version (`rustspray --output-version`). If the subprocess crashes or misses the frame deadline it is restarted up to `max_restarts` times, after which OWL logs the failure and falls back to the Python `exg` detector automatically.
+
+| Key | Default | Range / Valid values | Description |
+|-----|---------|---------------------|-------------|
+| `binary` | `/usr/local/bin/rustspray` | File path | Path to the `rustspray` binary (`rustspray-aarch64` for RPi 4/5, `rustspray-armv7` for RPi 3B+) |
+| `config` | `/etc/rustspray/config.toml` | File path | Rust-Spray TOML config (thresholds, lanes, GPIO pins) |
+| `mock_gpio` | `False` | `True` / `False` | Rust-Spray logs GPIO changes to stderr instead of driving pins. Use for development or when OWL's relay controller owns the pins |
+| `frame_timeout_ms` | `100` | 10--5000 (integer) | Per-frame IPC deadline. 100 ms is safe at up to 30 km/h |
+| `max_restarts` | `3` | 0--10 (integer) | Subprocess restarts before falling back to the `exg` detector |
 
 ### `[Controller]`
 

--- a/controller/shared/js/config.js
+++ b/controller/shared/js/config.js
@@ -12,7 +12,7 @@
  */
 const CONFIG_FIELD_DEFS = {
     'System': {
-        'algorithm': { type: 'select', options: ['exhsv', 'exg', 'hsv', 'gog', 'gog-hybrid'], help: 'Detection algorithm' },
+        'algorithm': { type: 'select', options: ['exhsv', 'exg', 'hsv', 'gog', 'gog-hybrid', 'rustspray'], help: 'Detection algorithm' },
         'input_file_or_directory': { type: 'text', help: 'Leave empty for camera input' },
         'relay_num': { type: 'select', options: ['1', '2', '4', '8', '12', '16'], help: 'Number of relays' },
         'actuation_duration': { type: 'number', step: 0.01, min: 0.01, max: 2.0, help: 'Spray duration in seconds' },
@@ -115,6 +115,13 @@ const CONFIG_FIELD_DEFS = {
         'track_class_window': { type: 'number', min: 1, max: 20, help: 'Frames of class history for majority vote' },
         'track_crop_persist': { type: 'number', min: 1, max: 10, help: 'Frames to persist crop mask after detection drops' },
         'detection_persist_frames': { type: 'number', min: 0, max: 15, step: 1, help: 'Frames to persist lost detections via Kalman prediction (0=disabled, 5=~0.5s)' }
+    },
+    'RustSpray': {
+        'binary': { type: 'text', help: 'Path to the rustspray binary' },
+        'config': { type: 'text', help: 'Path to the Rust-Spray TOML config (thresholds + GPIO pins)' },
+        'mock_gpio': { type: 'boolean', help: 'Log GPIO changes to stderr instead of driving pins (development)' },
+        'frame_timeout_ms': { type: 'number', min: 10, max: 5000, help: 'Per-frame IPC timeout in milliseconds' },
+        'max_restarts': { type: 'number', min: 0, max: 10, help: 'Subprocess restarts before falling back to exg' }
     },
     'Relays': { _isRelaySection: true }
 };

--- a/owl.py
+++ b/owl.py
@@ -579,9 +579,22 @@ class Owl:
         # updated by SensitivityManager.apply_preset(), so do NOT re-read from config.
 
         def _create_detector(algo):
-            """Three-way detector factory."""
+            """Detector factory: gog, gog-hybrid, rustspray or GreenOnBrown."""
             current_classes = self._detect_classes_list or None
-            if algo == 'gog':
+            if algo == 'rustspray':
+                from utils.rustspray_detector import RustSprayDetector
+                return RustSprayDetector(
+                    binary_path=self.config.get('RustSpray', 'binary',
+                                                fallback='/usr/local/bin/rustspray'),
+                    config_path=self.config.get('RustSpray', 'config',
+                                                fallback='/etc/rustspray/config.toml'),
+                    num_lanes=self.relay_num,
+                    mock_gpio=self.config.getboolean('RustSpray', 'mock_gpio', fallback=False),
+                    frame_timeout_s=self.config.getint('RustSpray', 'frame_timeout_ms',
+                                                       fallback=100) / 1000.0,
+                    max_restarts=self.config.getint('RustSpray', 'max_restarts', fallback=3),
+                )
+            elif algo == 'gog':
                 from utils.greenongreen import GreenOnGreen
                 return GreenOnGreen(
                     model_path=self._model_path,
@@ -606,8 +619,17 @@ class Owl:
             else:
                 return GreenOnBrown(algorithm=algo)
 
+        def _close_detector(detector):
+            """Release subprocess-backed detectors (e.g. Rust-Spray)."""
+            if detector is not None and hasattr(detector, 'close'):
+                try:
+                    detector.close()
+                except Exception as e:
+                    self.logger.warning(f"Error closing detector: {e}")
+
         try:
             weed_detector = _create_detector(algorithm)
+            self._active_detector = weed_detector
             if algorithm in ('gog', 'gog-hybrid'):
                 self._gog_detector = weed_detector
 
@@ -615,6 +637,7 @@ class Owl:
             self.logger.error(f"[ERROR] Failed to create detector for '{algorithm}': {e}")
             self.logger.error("[ERROR] OWL will continue running without detection. Change algorithm via dashboard to recover.")
             weed_detector = None
+            self._active_detector = None
             if self.dash:
                 self.dash.state['algorithm_error'] = str(e)
 
@@ -685,7 +708,10 @@ class Owl:
                 # Live algorithm switching
                 if self._pending_algorithm and (weed_detector is None or self._pending_algorithm != algorithm):
                     try:
-                        weed_detector = _create_detector(self._pending_algorithm)
+                        new_detector = _create_detector(self._pending_algorithm)
+                        _close_detector(weed_detector)
+                        weed_detector = new_detector
+                        self._active_detector = weed_detector
                         algorithm = self._pending_algorithm
                         if algorithm in ('gog', 'gog-hybrid'):
                             self._gog_detector = weed_detector
@@ -706,7 +732,10 @@ class Owl:
                     self._pending_model = None
                     try:
                         self._model_path = new_model
-                        weed_detector = _create_detector(algorithm)
+                        new_detector = _create_detector(algorithm)
+                        _close_detector(weed_detector)
+                        weed_detector = new_detector
+                        self._active_detector = weed_detector
                         if algorithm in ('gog', 'gog-hybrid'):
                             self._gog_detector = weed_detector
                         self.logger.info(f"Live model switch to: {new_model}")
@@ -787,6 +816,43 @@ class Owl:
                             brightness_min=self.brightness_min, brightness_max=self.brightness_max,
                             min_detection_area=self.min_detection_area, invert_hue=self.invert_hue
                         )
+                    elif algorithm == 'rustspray':
+                        try:
+                            cnts, boxes, weed_centres, image_out = weed_detector.inference(
+                                cropped_frame,
+                                show_display=return_image_out,
+                                label='WEED'
+                            )
+                        except RuntimeError as e:
+                            # Rust-Spray inner loop failed permanently (crashed or
+                            # timed out beyond max_restarts) — fall back to the
+                            # Python ExG detector so spraying continues.
+                            self.logger.error(f"[ERROR] Rust-Spray backend failed: {e}")
+                            self.logger.error("[ERROR] Falling back to Python 'exg' detector.")
+                            _close_detector(weed_detector)
+                            algorithm = 'exg'
+                            weed_detector = _create_detector(algorithm)
+                            self._active_detector = weed_detector
+                            if self.dash:
+                                self.dash.state['algorithm'] = algorithm
+                                self.dash.state['algorithm_error'] = (
+                                    f"rustspray backend failed ({e}) — fell back to exg")
+                            cnts, boxes, weed_centres, image_out = weed_detector.inference(
+                                cropped_frame,
+                                exg_min=self.exg_min,
+                                exg_max=self.exg_max,
+                                hue_min=self.hue_min,
+                                hue_max=self.hue_max,
+                                saturation_min=self.saturation_min,
+                                saturation_max=self.saturation_max,
+                                brightness_min=self.brightness_min,
+                                brightness_max=self.brightness_max,
+                                show_display=return_image_out,
+                                algorithm=algorithm,
+                                min_detection_area=self.min_detection_area,
+                                invert_hue=self.invert_hue,
+                                label='WEED'
+                            )
                     else:
                         cnts, boxes, weed_centres, image_out = weed_detector.inference(
                             cropped_frame,
@@ -1047,6 +1113,15 @@ class Owl:
                         self.logger.error(f"Failed to terminate {name}: {terminate_error}")
 
         try:
+            # Stop subprocess-backed detector (e.g. Rust-Spray inner loop)
+            detector = getattr(self, '_active_detector', None)
+            if detector is not None and hasattr(detector, 'close'):
+                try:
+                    detector.close()
+                    self.logger.info("Stopped detector backend")
+                except Exception as e:
+                    self.logger.warning(f"Failed to close detector backend: {e}")
+
             # Stop controller processes
             if hasattr(self, 'controller') and self.controller:
                 safe_stop(self.controller, 'controller', fallback_to_terminate=False)
@@ -1610,6 +1685,16 @@ if __name__ == "__main__":
         show_display=args.show_display,
         input_file_or_directory=args.input
     )
+
+    # Shut down cleanly on `systemctl stop owl` (SIGTERM) so subprocess-backed
+    # detectors (Rust-Spray) and relays are released properly.
+    import signal
+
+    def _sigterm_handler(signum, frame):
+        logger.info("SIGTERM received - shutting down OWL")
+        owl.stop()
+
+    signal.signal(signal.SIGTERM, _sigterm_handler)
 
     # start the targeting!
     owl.hoot()

--- a/tests/test_rustspray_detector.py
+++ b/tests/test_rustspray_detector.py
@@ -1,0 +1,327 @@
+"""Integration tests for the Rust-Spray detector backend.
+
+The real Rust-Spray binary is built from github.com/cropcrusaders/Rust-Spray
+and isn't available in this repo's CI, so these tests exercise
+RustSprayDetector against a stdlib-only fake binary that implements IPC
+protocol v1 exactly as documented in Rust-Spray's INTEGRATION.md:
+
+  stdin  <- [u32 width LE][u32 height LE][width*height*3 bytes RGB24]
+  stdout -> {"v":1,"frame":N,"ts_us":T,"lanes":[bool,...],"latency_us":L}\n
+
+This doubles as an executable specification of the protocol: if either side
+changes the contract, these tests break.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utils.rustspray_detector import RustSprayDetector
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.skipif(os.name == 'nt', reason='fake binary relies on a shebang (POSIX only)'),
+]
+
+NUM_LANES = 4
+WIDTH, HEIGHT = 64, 48
+LANE_WIDTH = WIDTH // NUM_LANES
+
+# ExG = 2G - R - B. Brown soil: 2*90 - 120 - 50 = 10 (below threshold).
+# Green weed: 2*200 - 40 - 40 = 320 (well above threshold).
+BROWN_BGR = (50, 90, 120)
+GREEN_BGR = (40, 200, 40)
+
+FAKE_RUSTSPRAY = r'''#!/usr/bin/env python3
+"""Stand-in for the Rust-Spray binary implementing IPC protocol v1.
+
+Behaviour toggles (env vars, set by tests):
+  FAKE_RUSTSPRAY_PROTOCOL   -- protocol version to report and emit (default 1)
+  FAKE_RUSTSPRAY_HANG_AFTER -- frame index at which to stop responding
+  FAKE_RUSTSPRAY_DIE_AFTER  -- frame index at which to exit(1) without responding
+"""
+import json
+import os
+import struct
+import sys
+import time
+
+PROTOCOL = int(os.environ.get('FAKE_RUSTSPRAY_PROTOCOL', '1'))
+HANG_AFTER = os.environ.get('FAKE_RUSTSPRAY_HANG_AFTER')
+DIE_AFTER = os.environ.get('FAKE_RUSTSPRAY_DIE_AFTER')
+NUM_LANES = 4
+EXG_THRESHOLD = 20
+
+if '--output-version' in sys.argv:
+    print(json.dumps({'rustspray_version': '0.3.0-fake', 'ipc_protocol': PROTOCOL}))
+    sys.exit(0)
+
+if '--ipc-mode' not in sys.argv:
+    sys.exit(2)
+
+mock_gpio = '--mock-gpio' in sys.argv
+
+
+def read_exact(stream, n):
+    data = b''
+    while len(data) < n:
+        chunk = stream.read(n - len(data))
+        if not chunk:
+            return None
+        data += chunk
+    return data
+
+
+frame_num = 0
+prev_lanes = [False] * NUM_LANES
+while True:
+    header = read_exact(sys.stdin.buffer, 8)
+    if header is None:
+        sys.exit(0)  # clean shutdown on stdin EOF
+    width, height = struct.unpack('<II', header)
+    pixels = read_exact(sys.stdin.buffer, width * height * 3)
+    if pixels is None:
+        sys.exit(1)
+
+    if DIE_AFTER is not None and frame_num >= int(DIE_AFTER):
+        sys.exit(1)
+    if HANG_AFTER is not None and frame_num >= int(HANG_AFTER):
+        time.sleep(3600)
+
+    start = time.time()
+    lane_width = width // NUM_LANES
+    lanes = []
+    for lane in range(NUM_LANES):
+        acc = 0
+        count = 0
+        for y in range(0, height, 4):
+            row = y * width * 3
+            for x in range(lane * lane_width, (lane + 1) * lane_width, 4):
+                i = row + x * 3
+                r, g, b = pixels[i], pixels[i + 1], pixels[i + 2]
+                acc += 2 * g - r - b
+                count += 1
+        lanes.append(acc / max(count, 1) > EXG_THRESHOLD)
+
+    if mock_gpio:
+        for lane, (prev, cur) in enumerate(zip(prev_lanes, lanes)):
+            if prev != cur:
+                state = 'ON' if cur else 'OFF'
+                print('[MOCK GPIO] lane=%d state=%s' % (lane, state),
+                      file=sys.stderr, flush=True)
+    prev_lanes = lanes
+
+    response = {
+        'v': PROTOCOL,
+        'frame': frame_num,
+        'ts_us': int(time.time() * 1e6),
+        'lanes': lanes,
+        'latency_us': int((time.time() - start) * 1e6),
+    }
+    sys.stdout.write(json.dumps(response) + '\n')
+    sys.stdout.flush()
+    frame_num += 1
+'''
+
+
+def make_frame(green_lanes=(), width=WIDTH, height=HEIGHT):
+    """Synthetic BGR frame: brown soil with whole lanes painted green."""
+    frame = np.zeros((height, width, 3), dtype=np.uint8)
+    frame[:] = BROWN_BGR
+    lane_width = width // NUM_LANES
+    for lane in green_lanes:
+        frame[:, lane * lane_width:(lane + 1) * lane_width] = GREEN_BGR
+    return frame
+
+
+@pytest.fixture
+def fake_binary(tmp_path):
+    binary = tmp_path / 'rustspray'
+    binary.write_text(FAKE_RUSTSPRAY)
+    binary.chmod(0o755)
+    config = tmp_path / 'config.toml'
+    config.write_text('# fake Rust-Spray config\n')
+    return binary, config
+
+
+@pytest.fixture
+def detector_factory(fake_binary):
+    """Create detectors against the fake binary; close them all on teardown."""
+    created = []
+
+    def factory(**kwargs):
+        binary, config = fake_binary
+        kwargs.setdefault('frame_timeout_s', 0.5)
+        detector = RustSprayDetector(
+            binary_path=str(binary),
+            config_path=str(config),
+            num_lanes=NUM_LANES,
+            mock_gpio=True,
+            **kwargs,
+        )
+        created.append(detector)
+        return detector
+
+    yield factory
+    for detector in created:
+        detector.close()
+
+
+class TestStartupHandshake:
+    def test_version_handshake_succeeds(self, detector_factory):
+        detector = detector_factory()
+        assert detector.backend_version == '0.3.0-fake'
+        assert detector._health_check()
+
+    def test_protocol_version_mismatch_raises(self, fake_binary, monkeypatch):
+        monkeypatch.setenv('FAKE_RUSTSPRAY_PROTOCOL', '2')
+        binary, config = fake_binary
+        with pytest.raises(RuntimeError, match='protocol'):
+            RustSprayDetector(str(binary), str(config), num_lanes=NUM_LANES)
+
+    def test_missing_binary_raises(self, fake_binary):
+        _, config = fake_binary
+        with pytest.raises(RuntimeError, match='not found'):
+            RustSprayDetector('/nonexistent/rustspray', str(config), num_lanes=NUM_LANES)
+
+
+class TestDetection:
+    def test_no_weed_gives_no_detections(self, detector_factory):
+        detector = detector_factory()
+        cnts, boxes, weed_centres, image_out = detector.inference(make_frame())
+        assert cnts == []
+        assert boxes == []
+        assert weed_centres == []
+        assert detector.last_lane_states == [False] * NUM_LANES
+
+    def test_single_green_lane_maps_to_correct_relay(self, detector_factory):
+        detector = detector_factory()
+        _, boxes, weed_centres, _ = detector.inference(make_frame(green_lanes=(2,)))
+
+        assert detector.last_lane_states == [False, False, True, False]
+        assert len(boxes) == 1 and len(weed_centres) == 1
+
+        # Centre must map back to relay 2 via owl.py's mapping:
+        # relay_id = int(centre_x / lane_width), gated on centre_y >= threshold
+        centre_x, centre_y = weed_centres[0]
+        assert int(centre_x / LANE_WIDTH) == 2
+        assert centre_y == HEIGHT - 1  # bottom-anchored: always inside actuation zone
+
+        x, y, w, h = boxes[0]
+        assert x == 2 * LANE_WIDTH and w == LANE_WIDTH and h == HEIGHT
+
+    def test_all_lanes_green(self, detector_factory):
+        detector = detector_factory()
+        _, boxes, weed_centres, _ = detector.inference(make_frame(green_lanes=range(NUM_LANES)))
+        assert detector.last_lane_states == [True] * NUM_LANES
+        relay_ids = sorted(int(cx / LANE_WIDTH) for cx, _ in weed_centres)
+        assert relay_ids == list(range(NUM_LANES))
+
+    def test_response_metadata_recorded(self, detector_factory):
+        detector = detector_factory()
+        detector.inference(make_frame(green_lanes=(0,)))
+        assert detector.last_latency_us is not None and detector.last_latency_us >= 0
+
+    def test_ignores_greenonbrown_kwargs(self, detector_factory):
+        """owl.py's GoB call signature must be accepted (thresholds live in
+        Rust-Spray's TOML, so the kwargs are ignored)."""
+        detector = detector_factory()
+        _, boxes, _, _ = detector.inference(
+            make_frame(green_lanes=(1,)),
+            exg_min=25, exg_max=200, hue_min=39, hue_max=83,
+            saturation_min=50, saturation_max=220,
+            brightness_min=60, brightness_max=190,
+            show_display=False, algorithm='rustspray',
+            min_detection_area=10, invert_hue=False, label='WEED')
+        assert len(boxes) == 1
+
+    def test_detect_convenience_api(self, detector_factory):
+        detector = detector_factory()
+        boxes, annotated, lane_states = detector.detect(make_frame(green_lanes=(3,)))
+        assert lane_states == [False, False, False, True]
+        assert len(boxes) == 1
+        assert annotated.shape == (HEIGHT, WIDTH, 3)
+
+    def test_mock_gpio_logs_state_changes(self, detector_factory):
+        detector = detector_factory()
+        detector.inference(make_frame(green_lanes=(1,)))
+        deadline = time.time() + 2.0
+        while time.time() < deadline:
+            if any('[MOCK GPIO] lane=1 state=ON' in line for line in detector._stderr_tail):
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail(f"No mock GPIO line seen on stderr: {list(detector._stderr_tail)}")
+
+
+class TestRestartAndFallback:
+    def test_recovers_when_subprocess_hangs(self, detector_factory, monkeypatch):
+        monkeypatch.setenv('FAKE_RUSTSPRAY_HANG_AFTER', '2')
+        detector = detector_factory()
+
+        detector.inference(make_frame())                # frame 0 — ok
+        detector.inference(make_frame())                # frame 1 — ok
+        # frame 2 hangs -> timeout -> transparent restart -> resent frame succeeds
+        _, boxes, _, _ = detector.inference(make_frame(green_lanes=(0,)))
+        assert detector.last_lane_states[0] is True
+        assert detector._restart_count == 1
+
+    def test_recovers_when_subprocess_dies_mid_run(self, detector_factory, monkeypatch):
+        monkeypatch.setenv('FAKE_RUSTSPRAY_DIE_AFTER', '1')
+        detector = detector_factory()
+
+        detector.inference(make_frame())                # frame 0 — ok
+        # frame 1: subprocess exits(1) after reading the frame, before replying
+        _, _, weed_centres, _ = detector.inference(make_frame(green_lanes=(2,)))
+        assert len(weed_centres) == 1
+        assert detector._restart_count == 1
+
+    def test_recovers_when_killed_externally(self, detector_factory):
+        detector = detector_factory()
+        detector.inference(make_frame())
+
+        detector._process.kill()
+        detector._process.wait()
+
+        _, _, weed_centres, _ = detector.inference(make_frame(green_lanes=(1,)))
+        assert len(weed_centres) == 1
+        assert detector._restart_count == 1
+
+    def test_raises_runtime_error_after_max_restarts(self, detector_factory, monkeypatch):
+        """After max_restarts the detector must raise RuntimeError so owl.py
+        falls back to the Python ExG detector."""
+        monkeypatch.setenv('FAKE_RUSTSPRAY_DIE_AFTER', '0')  # dies on every frame
+        detector = detector_factory(max_restarts=2)
+
+        with pytest.raises(RuntimeError, match='after 2 restart'):
+            detector.inference(make_frame())
+
+
+class TestShutdown:
+    def test_close_terminates_subprocess(self, detector_factory):
+        detector = detector_factory()
+        process = detector._process
+        detector.close()
+
+        assert process.poll() is not None
+        assert detector._process is None
+        assert not detector._health_check()
+
+    def test_close_is_idempotent(self, detector_factory):
+        detector = detector_factory()
+        detector.close()
+        detector.close()
+
+    def test_inference_after_close_raises(self, detector_factory):
+        detector = detector_factory()
+        detector.close()
+        with pytest.raises(RuntimeError, match='closed'):
+            detector.inference(make_frame())

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -130,15 +130,19 @@ class ConfigValidator:
         'track_class_window': ('int', 1, 20),
         'track_crop_persist': ('int', 1, 10),
         'detection_persist_frames': ('int', 0, 15),
+        # RustSpray backend
+        'frame_timeout_ms': ('int', 10, 5000),
+        'max_restarts': ('int', 0, 10),
         # Boolean fields
         'image_sample_enable': ('bool', None, None),
         'detection_enable': ('bool', None, None),
         'log_fps': ('bool', None, None),
         'invert_hue': ('bool', None, None),
         'tracking_enabled': ('bool', None, None),
+        'mock_gpio': ('bool', None, None),
     }
 
-    VALID_ALGORITHMS = {'exg', 'exgr', 'maxg', 'nexg', 'exhsv', 'hsv', 'gndvi', 'gog', 'gog-hybrid'}
+    VALID_ALGORITHMS = {'exg', 'exgr', 'maxg', 'nexg', 'exhsv', 'hsv', 'gndvi', 'gog', 'gog-hybrid', 'rustspray'}
 
     @classmethod
     def get_valid_algorithms(cls):
@@ -194,6 +198,10 @@ class ConfigValidator:
                               'new_track_thresh', 'track_buffer', 'match_thresh',
                               'track_class_window', 'track_crop_persist',
                               'detection_persist_frames'}
+        },
+        'RustSpray': {
+            'optional_keys': {'binary', 'config', 'mock_gpio',
+                              'frame_timeout_ms', 'max_restarts'}
         },
     }
 

--- a/utils/rustspray_detector.py
+++ b/utils/rustspray_detector.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python
+"""Wraps the Rust-Spray binary as a high-performance detection inner loop.
+
+Rust-Spray (github.com/cropcrusaders/Rust-Spray) performs SIMD-accelerated
+colour-based weed detection (ExG / green-ratio / chroma) and can drive the
+solenoid GPIO pins itself. OWL remains the outer shell: it owns frame capture
+(picamera2), scheduling, logging, the dashboard and config management, and
+streams frames to the Rust-Spray subprocess over stdin.
+
+IPC protocol v1 (see INTEGRATION.md in the Rust-Spray repository):
+  stdin  <- [u32 width LE][u32 height LE][width*height*3 bytes RGB24]
+  stdout -> {"v":1,"frame":N,"ts_us":T,"lanes":[bool,...],"latency_us":L}\n
+
+If the subprocess dies or times out it is restarted up to ``max_restarts``
+times; after that ``inference()`` raises RuntimeError so the caller (owl.py)
+can fall back to the Python ExG detector.
+"""
+import atexit
+import json
+import logging
+import queue
+import struct
+import subprocess
+import threading
+from collections import deque
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class RustSprayIPCError(Exception):
+    """Transient IPC failure (timeout, dead subprocess, bad response).
+
+    Handled internally by restarting the subprocess — never escapes
+    ``inference()``. Permanent failures raise RuntimeError instead.
+    """
+
+
+class RustSprayDetector:
+    """Duck-typed OWL detector backed by the Rust-Spray subprocess.
+
+    Satisfies the same interface as GreenOnBrown: ``inference(image, ...)``
+    returning ``(contours, boxes, weed_centres, image_out)``. Rust-Spray
+    reports per-lane spray decisions rather than pixel contours, so each
+    active lane is converted to one synthetic detection: a box spanning the
+    lane and a centre anchored at the bottom of the frame. Bottom-anchoring
+    guarantees the centre passes owl.py's actuation-zone gate
+    (``centre[1] >= actuation_y_thresh``), because Rust-Spray has already
+    decided that lane should fire.
+    """
+
+    PROTOCOL_VERSION = 1
+    STARTUP_TIMEOUT_S = 5.0
+    FRAME_TIMEOUT_S = 0.10   # 100 ms — safe at up to 30 km/h
+    MAX_RESTARTS = 3
+
+    def __init__(self, binary_path: str, config_path: str,
+                 num_lanes: int = 4, mock_gpio: bool = False,
+                 frame_timeout_s: float = None, max_restarts: int = None,
+                 startup_timeout_s: float = None):
+        self.binary_path = str(binary_path)
+        self.config_path = str(config_path)
+        self.num_lanes = int(num_lanes)
+        self.mock_gpio = bool(mock_gpio)
+        self.frame_timeout_s = self.FRAME_TIMEOUT_S if frame_timeout_s is None else float(frame_timeout_s)
+        self.max_restarts = self.MAX_RESTARTS if max_restarts is None else int(max_restarts)
+        self.startup_timeout_s = self.STARTUP_TIMEOUT_S if startup_timeout_s is None else float(startup_timeout_s)
+
+        self.backend_version = None
+        self.last_lane_states = [False] * self.num_lanes
+        self.last_latency_us = None
+
+        self._process = None
+        self._stdout_queue = None
+        self._stderr_tail = deque(maxlen=20)
+        self._restart_count = 0
+        self._frames_since_start = 0
+        self._closed = False
+        self._lock = threading.RLock()
+
+        self._verify_protocol_version()
+        self._start_process()
+        # Belt-and-braces: never leave an orphaned subprocess holding GPIO
+        atexit.register(self.close)
+
+    # ------------------------------------------------------------------ #
+    # OWL detector interface
+    # ------------------------------------------------------------------ #
+
+    def inference(self, image, show_display=False, label='WEED', **kwargs):
+        """Drop-in replacement for GreenOnBrown.inference().
+
+        Accepts (and ignores) the GreenOnBrown threshold kwargs — colour
+        thresholds live in Rust-Spray's own TOML config.
+
+        Returns (contours, boxes, weed_centres, image_out). Contours are
+        always empty; boxes/centres are synthesised per active lane.
+        """
+        if image.ndim != 3 or image.shape[2] != 3:
+            raise ValueError(f"Expected a 3-channel BGR frame, got shape {image.shape}")
+
+        height, width = image.shape[:2]
+        # OWL frames are BGR (OpenCV); protocol v1 wants RGB24, R first
+        frame_rgb24 = np.ascontiguousarray(image[:, :, ::-1]).tobytes()
+
+        response = self._send_frame_with_recovery(frame_rgb24, width, height)
+
+        lanes = [bool(state) for state in response.get('lanes', [])][:self.num_lanes]
+        lanes += [False] * (self.num_lanes - len(lanes))
+        self.last_lane_states = lanes
+        self.last_latency_us = response.get('latency_us')
+
+        boxes, weed_centres = self._lanes_to_detections(lanes, width, height)
+
+        image_out = image
+        if show_display and boxes:
+            image_out = self._annotate(image, boxes, label)
+
+        return [], boxes, weed_centres, image_out
+
+    def detect(self, frame: np.ndarray, confidence: float = 0.5,
+               filter_id: int = 0, **kwargs):
+        """Convenience API per the integration spec.
+
+        Returns (boxes, annotated_frame, lane_states).
+        """
+        _, boxes, _, annotated = self.inference(frame, show_display=True, **kwargs)
+        return boxes, annotated, list(self.last_lane_states)
+
+    def close(self) -> None:
+        """Terminate the subprocess cleanly. Idempotent."""
+        with self._lock:
+            self._closed = True
+            self._terminate_process()
+        atexit.unregister(self.close)
+
+    # ------------------------------------------------------------------ #
+    # Subprocess lifecycle
+    # ------------------------------------------------------------------ #
+
+    def _verify_protocol_version(self) -> None:
+        """Startup handshake: run `rustspray --output-version` and check
+        the IPC protocol version before sending any frames."""
+        try:
+            result = subprocess.run(
+                [self.binary_path, '--output-version'],
+                capture_output=True, text=True, timeout=self.startup_timeout_s,
+            )
+        except FileNotFoundError:
+            raise RuntimeError(f"Rust-Spray binary not found: {self.binary_path}")
+        except subprocess.TimeoutExpired:
+            raise RuntimeError(
+                f"Rust-Spray did not answer --output-version within "
+                f"{self.startup_timeout_s}s: {self.binary_path}")
+        except OSError as e:
+            raise RuntimeError(f"Cannot execute Rust-Spray binary {self.binary_path}: {e}")
+
+        try:
+            info = json.loads(result.stdout.strip().splitlines()[-1])
+        except (ValueError, IndexError):
+            raise RuntimeError(
+                f"Rust-Spray --output-version returned invalid JSON "
+                f"(exit code {result.returncode}): {result.stdout!r}")
+
+        protocol = info.get('ipc_protocol')
+        if protocol != self.PROTOCOL_VERSION:
+            raise RuntimeError(
+                f"Rust-Spray IPC protocol mismatch: binary speaks v{protocol}, "
+                f"this detector requires v{self.PROTOCOL_VERSION}. "
+                f"Update Rust-Spray or OWL so the versions match.")
+
+        self.backend_version = info.get('rustspray_version', 'unknown')
+        logger.info(f"Rust-Spray {self.backend_version} (IPC protocol v{protocol}) at {self.binary_path}")
+
+    def _start_process(self) -> None:
+        """Spawn the rustspray subprocess. Called at init and on restart."""
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("RustSprayDetector is closed")
+
+            cmd = [self.binary_path, '--ipc-mode', '--config', self.config_path]
+            if self.mock_gpio:
+                cmd.append('--mock-gpio')
+
+            self._process = subprocess.Popen(
+                cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                bufsize=0,
+            )
+            self._stdout_queue = queue.Queue()
+            self._frames_since_start = 0
+
+            threading.Thread(
+                target=self._read_stdout,
+                args=(self._process, self._stdout_queue),
+                daemon=True, name='rustspray-stdout').start()
+            threading.Thread(
+                target=self._read_stderr,
+                args=(self._process,),
+                daemon=True, name='rustspray-stderr').start()
+
+            logger.info(f"Started Rust-Spray subprocess (pid {self._process.pid}): {' '.join(cmd)}")
+
+    @staticmethod
+    def _read_stdout(process, out_queue) -> None:
+        """Daemon reader thread: enforces FRAME_TIMEOUT_S without blocking
+        OWL's main loop (the loop waits on the queue with a timeout instead
+        of blocking on the pipe). Puts None on EOF so a dead subprocess is
+        detected immediately rather than after a full timeout."""
+        try:
+            for line in iter(process.stdout.readline, b''):
+                out_queue.put(line)
+        except (ValueError, OSError):
+            pass  # pipe closed during shutdown
+        out_queue.put(None)
+
+    def _read_stderr(self, process) -> None:
+        try:
+            for raw in iter(process.stderr.readline, b''):
+                line = raw.decode('utf-8', errors='replace').rstrip()
+                if line:
+                    self._stderr_tail.append(line)
+                    logger.debug(f"[rustspray] {line}")
+        except (ValueError, OSError):
+            pass
+
+    def _terminate_process(self) -> None:
+        process = self._process
+        self._process = None
+        if process is None or process.poll() is not None:
+            return
+        try:
+            # closing stdin signals EOF — rustspray exits cleanly in IPC mode
+            if process.stdin:
+                process.stdin.close()
+            process.wait(timeout=1.0)
+        except (subprocess.TimeoutExpired, OSError):
+            try:
+                process.terminate()
+                process.wait(timeout=0.5)
+            except (subprocess.TimeoutExpired, OSError):
+                process.kill()
+                try:
+                    process.wait(timeout=0.5)
+                except (subprocess.TimeoutExpired, OSError):
+                    pass
+
+    def _health_check(self) -> bool:
+        """Return True if subprocess is alive and IPC protocol version matched."""
+        with self._lock:
+            return (not self._closed
+                    and self.backend_version is not None
+                    and self._process is not None
+                    and self._process.poll() is None)
+
+    # ------------------------------------------------------------------ #
+    # IPC
+    # ------------------------------------------------------------------ #
+
+    def _send_frame(self, frame_rgb24: bytes, width: int, height: int) -> dict:
+        """Write one frame to stdin, read the JSON response from stdout."""
+        process = self._process
+        if process is None or process.poll() is not None:
+            raise RustSprayIPCError(self._death_message(process))
+
+        header = struct.pack('<II', width, height)
+        try:
+            # header + pixels in a single write per the IPC contract
+            process.stdin.write(header + frame_rgb24)
+            process.stdin.flush()
+        except (BrokenPipeError, OSError) as e:
+            raise RustSprayIPCError(f"stdin write failed: {e}. {self._death_message(process)}")
+
+        # Allow the (re)started binary time to initialise before the first
+        # frame; steady-state frames get the strict per-frame budget.
+        timeout = self.startup_timeout_s if self._frames_since_start == 0 else self.frame_timeout_s
+        try:
+            line = self._stdout_queue.get(timeout=timeout)
+        except queue.Empty:
+            raise RustSprayIPCError(
+                f"no response within {timeout * 1000:.0f} ms "
+                f"(frame {self._frames_since_start} since start)")
+        if line is None:
+            raise RustSprayIPCError(self._death_message(process))
+
+        try:
+            response = json.loads(line)
+        except ValueError:
+            raise RustSprayIPCError(f"invalid JSON response: {line!r}")
+
+        version = response.get('v')
+        if version != self.PROTOCOL_VERSION:
+            raise RustSprayIPCError(
+                f"response protocol v{version} != expected v{self.PROTOCOL_VERSION}")
+
+        self._frames_since_start += 1
+        return response
+
+    def _send_frame_with_recovery(self, frame_rgb24: bytes, width: int, height: int) -> dict:
+        """Send a frame, restarting the subprocess on failure.
+
+        Raises RuntimeError once max_restarts is exhausted so owl.py can
+        fall back to the Python ExG detector.
+        """
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("RustSprayDetector is closed")
+            while True:
+                try:
+                    return self._send_frame(frame_rgb24, width, height)
+                except RustSprayIPCError as e:
+                    if self._restart_count >= self.max_restarts:
+                        self._terminate_process()
+                        raise RuntimeError(
+                            f"Rust-Spray backend failed after {self._restart_count} "
+                            f"restart(s): {e}")
+                    self._restart_count += 1
+                    logger.error(
+                        f"Rust-Spray IPC failure: {e} — restarting subprocess "
+                        f"({self._restart_count}/{self.max_restarts})")
+                    self._terminate_process()
+                    self._start_process()
+
+    def _death_message(self, process) -> str:
+        exit_code = process.poll() if process is not None else None
+        message = f"subprocess not running (exit code {exit_code})"
+        if self._stderr_tail:
+            message += f"; stderr tail: {' | '.join(list(self._stderr_tail)[-5:])}"
+        return message
+
+    # ------------------------------------------------------------------ #
+    # Lane state -> OWL detections
+    # ------------------------------------------------------------------ #
+
+    def _lanes_to_detections(self, lanes, width, height):
+        """Convert per-lane booleans into synthetic boxes/centres.
+
+        Lane i spans columns [i*lane_width, (i+1)*lane_width), matching
+        owl.py's relay mapping (relay_id = int(centre_x / lane_width)), so
+        each active lane maps back to exactly its own relay.
+        """
+        boxes = []
+        weed_centres = []
+        lane_width = width / self.num_lanes
+        for i, active in enumerate(lanes):
+            if not active:
+                continue
+            x = int(i * lane_width)
+            box_width = max(1, int(lane_width))
+            boxes.append([x, 0, box_width, height])
+            weed_centres.append([int((i + 0.5) * lane_width), height - 1])
+        return boxes, weed_centres
+
+    @staticmethod
+    def _annotate(image, boxes, label):
+        try:
+            import cv2
+        except ImportError:
+            return image
+        image_out = image.copy()
+        for x, y, w, h in boxes:
+            cv2.rectangle(image_out, (x, y), (x + w, y + h), (0, 0, 255), 2)
+            cv2.putText(image_out, label, (x + 5, 30),
+                        cv2.FONT_HERSHEY_SIMPLEX, 1.0, (255, 0, 0), 2)
+        return image_out


### PR DESCRIPTION
Integrates Rust-Spray (github.com/cropcrusaders/Rust-Spray) as an optional
high-performance detection backend, selected with `algorithm = rustspray`.
OWL remains the outer shell: picamera2 capture, scheduling, logging,
dashboard and relay control are unchanged, and all existing Python
detectors keep working.

- utils/rustspray_detector.py: RustSprayDetector wraps the rustspray
  binary over IPC protocol v1 (RGB24 frames on stdin, per-lane JSON on
  stdout). Verifies the protocol version at startup via --output-version,
  enforces a per-frame deadline with a daemon reader thread, restarts the
  subprocess on crash/timeout up to max_restarts, then raises RuntimeError.
  Duck-types GreenOnBrown.inference() by synthesising one bottom-anchored
  detection per active lane so owl.py's relay mapping fires the right lane.
- owl.py: rustspray branch in the detector factory, automatic fallback to
  the Python exg detector when the backend fails permanently, detector
  close on live algorithm/model switches and in stop(), and a SIGTERM
  handler so `systemctl stop owl` shuts the subprocess down cleanly.
- config: new optional [RustSpray] section (binary, config, mock_gpio,
  frame_timeout_ms, max_restarts) with validators, dashboard field
  definitions, and documentation in config/README.md.
- tests/test_rustspray_detector.py: exercises the wrapper against a
  stdlib-only fake binary that implements IPC protocol v1, covering the
  version handshake, lane-to-relay mapping, timeout/crash/kill restart
  paths, max-restart RuntimeError, and clean shutdown.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MiCQP149CfrJGScBm5jvcU